### PR TITLE
Update Parser.php

### DIFF
--- a/src/TextFormatter/Plugins/GithubIssueAutolink/Parser.php
+++ b/src/TextFormatter/Plugins/GithubIssueAutolink/Parser.php
@@ -17,7 +17,8 @@ class Parser extends ParserBase
             $tag = $this->parser->addSelfClosingTag(
                 $tagName,
                 $m[0][1],
-                \strlen($m[0][0])
+                \strlen($m[0][0]),
+                -10
             );
             $tag->setAttributes(
                 [
@@ -25,7 +26,6 @@ class Parser extends ParserBase
                     'issue' => $m[2][1] >= 0 ? $m[2][0] : $m[4][0],
                 ]
             );
-            $tag->setSortPriority(-10);
         }
     }
 }


### PR DESCRIPTION
made compliant with newest text formatter,

this caused an exception on discuss:

```
2018/10/31 17:48:44 [error] 20642#20642: *249099 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught Error: Call to undefined method s9e\TextFormatter\Parser\Tag::setSortPriority() in /home/forge/discuss.flarum.org/vendor/sijad/flarum-ext-github-autolink/src/TextFormatter/Plugins/GithubIssueAutolink/Parser.php:28
Stack trace:
#0 /home/forge/discuss.flarum.org/vendor/s9e/text-formatter/src/Parser.php(384): Sijad\GithubAutolink\TextFormatter\Plugins\GithubIssueAutolink\Parser->parse('https://github....', Array)
#1 /home/forge/discuss.flarum.org/vendor/s9e/text-formatter/src/Parser.php(390): s9e\TextFormatter\Parser->executePluginParser('GithubIssueAuto...')
#2 /home/forge/discuss.flarum.org/vendor/s9e/text-formatter/src/Parser.php(126): s9e\TextFormatter\Parser->executePluginParsers()
```